### PR TITLE
Follow the original Gamma-Omega default layout with HRM.

### DIFF
--- a/keyboards/tutte_coxeter_36k/keymaps/default/keymap.c
+++ b/keyboards/tutte_coxeter_36k/keymaps/default/keymap.c
@@ -13,15 +13,18 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       * │ Z │ X │ C │ V │ B │       │ N │ M │ , │ . │ / │
       * └───┴───┴───┴───┴───┘       └───┴───┴───┴───┴───┘
       *           ┌───┐                   ┌───┐
-      *           │GUI├───┐           ┌───┤Alt│
-      *           └───┤Bsp├───┐   ┌───┤Ent├───┘
-      *               └───┤   │   │   ├───┘
+      *           │Del├───┐           ┌───┤BkS│
+      *           └───┤Tab├───┐   ┌───┤Esc├───┘
+      *               └───┤Spc│   │Ent├───┘
       *                   └───┘   └───┘
+      * Home-row mods,
+      * ASDF are Left-GUI,    Left-Alt,  Left-Ctrl, Left-Shift
+      * JKL; are Right-Shift, Left-Ctrl, Left-Alt,  Left-GUI
       */
     [0] = LAYOUT_split_3x5_3(
-        KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,                               KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,
-        KC_A,    KC_S,    KC_D,    KC_F,    KC_G,                               KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN,
-        KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,                               KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH,
-                                   KC_LGUI, KC_BSPC, KC_SPC,           KC_SPC,  KC_ENT,  KC_RALT
+        KC_Q,               KC_W,               KC_E,               KC_R,               KC_T,      KC_Y,     KC_U,               KC_I,               KC_O,                KC_P,
+        MT(MOD_LGUI, KC_A), MT(MOD_LALT, KC_S), MT(MOD_LCTL, KC_D), MT(MOD_LSFT, KC_F), KC_G,      KC_H,     MT(MOD_RSFT, KC_J), MT(MOD_LCTL, KC_K), MT(MOD_LALT, KC_L),  MT(MOD_LGUI, KC_SCLN),
+        KC_Z,               KC_X,               KC_C,               KC_V,               KC_B,      KC_N,     KC_M,               KC_COMM,            KC_DOT,              KC_SLSH,
+                                                KC_DEL,             KC_TAB,             KC_SPC,    KC_ENT,   KC_ESC,             KC_BSPC
     )
 };


### PR DESCRIPTION
This is more functional than the QMK bare-bones default, although why the HRM on the right are not all right-modifiers escapes me. This is important where right-alt AKA AltGr is used for accents etc.