### PR TITLE
Enable controller's built-in WS2812 RGB LED on GP23 via json

### DIFF
--- a/keyboards/tutte_coxeter_36k/keyboard.json
+++ b/keyboards/tutte_coxeter_36k/keyboard.json
@@ -10,6 +10,13 @@
         "mousekey": true,
         "nkro": false
     },
+    "ws2812": {
+        "pin": "GP23",
+        "driver": "vendor"
+    },
+    "rgblight": {
+        "led_count": 1
+    },
     "matrix_pins": {
         "cols": ["GP11", "GP10", "GP3", "GP4", "GP7", "GP26", "GP27", "GP28", "GP15", "GP21", "GP19", "GP20", "GP16"],
         "rows": ["GP12", "GP8", "GP9", "GP1", "GP6", "GP2", "GP22", "GP0", "GP13", "GP14", "GP18", "GP17", "GP5"]

--- a/keyboards/tutte_coxeter_36k/keymaps/vial/rules.mk
+++ b/keyboards/tutte_coxeter_36k/keymaps/vial/rules.mk
@@ -1,2 +1,4 @@
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
+
+RGBLIGHT_ENABLE = yes


### PR DESCRIPTION
Replaces #7, still only seen solid red output